### PR TITLE
Changed wazowski via keymap to include skipped switch

### DIFF
--- a/keyboards/keebzdotnet/wazowski/keymaps/via/keymap.c
+++ b/keyboards/keebzdotnet/wazowski/keymaps/via/keymap.c
@@ -25,6 +25,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_BASE] = LAYOUT(
         KC_A, KC_B, KC_C,KC_D, KC_E,
         KC_F, KC_G, KC_H, KC_I, KC_J,
-        KC_K, KC_L, KC_M, KC_N
+        KC_K, KC_L, KC_NO, KC_M, KC_N
     ),
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Included the `KC_NO`key code in the Wazowski 23-19 VIA keymap since it is referenced in the matrix in wazowski.h

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
